### PR TITLE
Added Public Health Ontario data source.

### DIFF
--- a/case-rate.toml
+++ b/case-rate.toml
@@ -7,6 +7,10 @@ storage = "./covid19-data"
 repo = "https://github.com/CSSEGISandData/COVID-19"
 
 # COVID-19 data from the Public Health Agency of Canada
-[sources.phac]
+[sources.public-health-agency-canada]
 url = "https://health-infobase.canada.ca/src/data/covidLive/covid19.csv"
 info = "https://www.canada.ca/en/public-health/services/diseases/2019-novel-coronavirus-infection.html#a1"
+
+[sources.public-health-ontario]
+url = "https://data.ontario.ca/dataset/f4f86e54-872d-43f8-8a86-3892fd3cb5e6/resource/ed270bb8-340b-41f9-a7c6-e8ef587e6d11/download/covidtesting.csv"
+info = "https://data.ontario.ca/dataset/status-of-covid-19-cases-in-ontario"

--- a/src/case_rate/sources/__init__.py
+++ b/src/case_rate/sources/__init__.py
@@ -2,7 +2,7 @@ import pathlib
 from typing import Optional
 
 from .jhu_csse import JHUCSSESource
-from .phac import PHACSource
+from .public_health_agency_canada import PublicHealthAgencyCanadaSource
 from .public_health_ontario import PublicHealthOntarioSource
 
 from ..storage import InputSource
@@ -15,9 +15,9 @@ __all__ = [
 
 
 DATA_SOURCES = {
-    (None, None): JHUCSSESource,    # Default source
-    ('Canada', None): PHACSource,   # Canada-specific source
-    ('Canada', 'Ontario'): PublicHealthOntarioSource  # Ontario-specific Source
+    (None, None): JHUCSSESource,                       # Default source
+    ('Canada', None): PublicHealthAgencyCanadaSource,  # Canada-specific
+    ('Canada', 'Ontario'): PublicHealthOntarioSource   # Ontario-specific
 }
 
 

--- a/src/case_rate/sources/__init__.py
+++ b/src/case_rate/sources/__init__.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from .jhu_csse import JHUCSSESource
 from .phac import PHACSource
+from .public_health_ontario import PublicHealthOntarioSource
 
 from ..storage import InputSource
 
@@ -15,7 +16,8 @@ __all__ = [
 
 DATA_SOURCES = {
     (None, None): JHUCSSESource,    # Default source
-    ('Canada', None): PHACSource    # Canada-specific source
+    ('Canada', None): PHACSource,   # Canada-specific source
+    ('Canada', 'Ontario'): PublicHealthOntarioSource  # Ontario-specific Source
 }
 
 

--- a/src/case_rate/sources/public_health_agency_canada.py
+++ b/src/case_rate/sources/public_health_agency_canada.py
@@ -82,7 +82,7 @@ def _to_int(number: str) -> int:
     return int(number)
 
 
-class PHACSource(InputSource):
+class PublicHealthAgencyCanadaSource(InputSource):
     '''Uses reporting data published by the PHAC.
 
     This input source uses a CSV file that's regularly updated by the Public
@@ -119,7 +119,7 @@ class PHACSource(InputSource):
 
     @classmethod
     def name(cls) -> str:
-        return 'phac'
+        return 'public-health-agency-canada'
 
     @classmethod
     def details(cls) -> str:


### PR DESCRIPTION
Added [Public Health Ontario's status report](https://data.ontario.ca/dataset/status-of-covid-19-cases-in-ontario) as a data source to get Ontario-specific numbers.