### PR TITLE
Added extra check for PHO date format.

### DIFF
--- a/src/case_rate/sources/public_health_ontario.py
+++ b/src/case_rate/sources/public_health_ontario.py
@@ -48,7 +48,15 @@ def _to_date(date: str) -> datetime.date:
     datetime.date
         output ``date`` object
     '''
-    dt = datetime.datetime.strptime(date, '%Y-%m-%d')
+
+    fmt = '%Y-%m-%d'
+    alt_fmt = '%m/%d/%Y'
+
+    try:
+        dt = datetime.datetime.strptime(date, fmt)
+    except ValueError:
+        dt = datetime.datetime.strptime(date, alt_fmt)
+
     return dt.date()
 
 


### PR DESCRIPTION
Public Health Ontario seemed to have changed the date format from `YYYY-MM-DD` to `MM/DD/YYYY`.  This patch attempts both formats before reporting an error.