### PR TITLE
Changed JHU CSSE source to use shallow fetch.

### DIFF
--- a/src/case_rate/sources/jhu_csse.py
+++ b/src/case_rate/sources/jhu_csse.py
@@ -161,7 +161,7 @@ class JHUCSSESource(InputSource):
                 stdout, stderr = _git('pull', cwd=path)
         else:
             click.echo(f'Cloning "{repo}" to "{path}".')
-            stdout, stderr = _git('clone', repo, path.as_posix())
+            stdout, stderr = _git('clone', '--depth', '1', repo, path.as_posix())
 
         if len(stdout) != 0:
             click.secho('stdout', fg='green', bold=True)


### PR DESCRIPTION
The repository is quite large (~200MB) and its history means that a full clone just as large.  Because only the current state is required, using a `--depth 1` is good enough.