### PR TITLE
Record link to production site.

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -34,6 +34,8 @@ jobs:
 
     - name: Generate the nightly report using the latest COVID-19 data.
       run: make report
+      env:
+        CASE_RATE_URL: https://projects.rzeszutek.ca/case-rate/
 
     - name: Checkout the static-app branch in its own folder.
       uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ test:
 	pytest
 
 dist/.ignore:
-	# @mkdir dist
-	# @touch dist/.ignore
+	@mkdir dist
+	@touch dist/.ignore
 
 dist: dist/.ignore
 	@echo '-- Make dist/ folder...'

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ test:
 	pytest
 
 dist/.ignore:
-	@mkdir dist
-	@touch dist/.ignore
+	# @mkdir dist
+	# @touch dist/.ignore
 
 dist: dist/.ignore
 	@echo '-- Make dist/ folder...'

--- a/render_template.py
+++ b/render_template.py
@@ -12,9 +12,11 @@ import jinja2
               default='templates')
 @click.option('--timezone', help='Time zone string', metavar='TZ',
               type=str, default='America/Toronto')
+@click.option('--page-url', default='http://localhost:8000',
+              envvar='CASE_RATE_URL', help='Page\'s default URL.')
 @click.argument('src', type=str)
 @click.argument('dst', type=click.Path(dir_okay=False))
-def main(templates: str, timezone: str, src: str, dst: str):
+def main(templates: str, timezone: str, page_url: str, src: str, dst: str):
     '''Quickly generate Jinja-based HTML templates.'''
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(templates),
@@ -27,7 +29,7 @@ def main(templates: str, timezone: str, src: str, dst: str):
     today = datetime.datetime.now(tz)
 
     jinja_template = env.get_template(src)
-    html = jinja_template.render(date=today)
+    html = jinja_template.render(date=today, page_url=page_url)
     with output_file.open('wt') as f:
         f.write(html)
 

--- a/templates/details.jinja2
+++ b/templates/details.jinja2
@@ -3,7 +3,7 @@
 
 <div class="flex my-2 justify-center md:justify-start">
     <h1 class="text-3xl my-0">COVID-19 Cases</h1>
-    <a href=".." class="link mt-auto mb-1 mx-2">
+    <a href="{{ page_url }}" class="link mt-auto mb-1 mx-2">
         <!-- Icon from https://heroicons.com/ -->
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
The path to the production site is now passed to the template renderer to make it easier to go between pages.