### PR TITLE
Decommission the regularly updated COVID-19 dashboard.

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -1,10 +1,6 @@
 name: Generate nightly report.
 
 on:
-  # Run this nightly at 9:00pm (EST).
-  schedule:
-    - cron: "0 1 * * *"
-
   # Update anytime 'master' is updated.
   push:
     branches:

--- a/templates/base.jinja2
+++ b/templates/base.jinja2
@@ -10,6 +10,10 @@
     </head>
     <body>
         <div class="font-sans container md:mx-auto md:w-4/6">
+            <div class="font-light">
+                <span class="font-medium">Note:</span> This dashboard is no
+                longer being updated.  It remains here for archival purposes.
+            </div>
             {% block contents %}{% endblock %}
         </div>
     </body>


### PR DESCRIPTION
The nightly updating COVID-19 dashboard is being retired.  This adds a small banner-style message to the dashboard and removes the cron job from the `generate-report.yml` workflow.